### PR TITLE
Add separate login and authentication logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN mkdir /app/thumbnail_cache
 RUN mkdir /app/cache && mkdir /app/cache/reports && mkdir /app/cache/export \
     && mkdir /app/cache/request_cache && mkdir /app/cache/persistent_cache
 RUN mkdir /app/tmp && mkdir /app/persist
+RUN mkdir /app/logs
 RUN mkdir -p /root/gramps/gramps$GRAMPS_VERSION/plugins
 # set config options
 ENV GRAMPSWEB_USER_DB_URI=sqlite:////app/users/users.sqlite
@@ -54,6 +55,8 @@ ENV GRAMPSWEB_REQUEST_CACHE_CONFIG__CACHE_DIR=/app/cache/request_cache
 ENV GRAMPSWEB_PERSISTENT_CACHE_CONFIG__CACHE_DIR=/app/cache/persistent_cache
 ENV GRAMPSWEB_REPORT_DIR=/app/cache/reports
 ENV GRAMPSWEB_EXPORT_DIR=/app/cache/export
+ENV GRAMPSWEB_LOGIN_LOG_PATH=/app/logs/login.log
+ENV GRAMPSWEB_AUTH_LOG_PATH=/app/logs/auth.log
 ENV GRAMPSHOME=/root
 ENV GRAMPS_DATABASE_PATH=/root/.gramps/grampsdb
 
@@ -98,6 +101,7 @@ model = SentenceTransformer('sentence-transformers/distiluse-base-multilingual-c
     fi
 
 EXPOSE 5000
+VOLUME /app/logs
 
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/gramps_webapi/api/resources/token.py
+++ b/gramps_webapi/api/resources/token.py
@@ -21,6 +21,7 @@
 
 from typing import Any, Iterable
 
+import logging
 from flask import abort, current_app, request
 from flask_jwt_extended import (
     create_access_token,
@@ -89,7 +90,8 @@ class TokenResource(Resource):
         if is_tree_disabled(tree=tree_id):
             abort_with_message(503, "This tree is temporarily disabled")
         permissions = get_permissions(username=args["username"], tree=tree_id)
-        current_app.logger.info(
+        login_logger = logging.getLogger("login")
+        login_logger.info(
             "Login success: user %s from %s",
             args["username"],
             request.remote_addr,

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -71,6 +71,8 @@ class DefaultConfig(object):
     RATE_LIMIT_MEDIA_ARCHIVE = "1 per day"
     REGISTRATION_DISABLED = False
     LOG_LEVEL = "INFO"
+    LOGIN_LOG_PATH = str(Path.cwd() / "logs" / "login.log")
+    AUTH_LOG_PATH = str(Path.cwd() / "logs" / "auth.log")
     LLM_BASE_URL = None
     LLM_MODEL = ""
     LLM_MAX_CONTEXT_LENGTH = 50000


### PR DESCRIPTION
## Summary
- add config options for dedicated login and authentication log files
- configure Flask app to write login/auth events to separate loggers
- store those log files in `/app/logs` and expose as a Docker volume

## Testing
- `pre-commit run --files gramps_webapi/config.py gramps_webapi/app.py gramps_webapi/api/resources/token.py gramps_webapi/api/auth.py Dockerfile` *(failed: command not found)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'gramps')*


------
https://chatgpt.com/codex/tasks/task_e_688f2bdace78832e85e77ad8bb7009cd