### PR TITLE
Rotate auth logs at 30MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ Gramps Web API is the backend of [Gramps Web](https://www.grampsweb.org/), a gen
 ## Related projects
 
 - Gramps Web frontend repository: https://github.com/gramps-project/gramps-web
+
+## Logging
+
+Authentication events are written to `logs/auth.log`. This file is rotated
+automatically when it reaches 30 MB, keeping up to 10 backup files.

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -20,6 +20,7 @@
 """Flask web app providing a REST API to a Gramps family tree."""
 
 import logging
+from logging.handlers import RotatingFileHandler
 import os
 import warnings
 from pathlib import Path
@@ -58,7 +59,14 @@ def setup_special_loggers(app: Flask) -> None:
             continue
         log_file = Path(path)
         log_file.parent.mkdir(parents=True, exist_ok=True)
-        handler = logging.FileHandler(log_file)
+        if name == "auth":
+            handler = RotatingFileHandler(
+                log_file,
+                maxBytes=app.config.get("AUTH_LOG_MAX_BYTES", 30 * 1024 * 1024),
+                backupCount=app.config.get("AUTH_LOG_BACKUP_COUNT", 10),
+            )
+        else:
+            handler = logging.FileHandler(log_file)
         handler.setLevel(logging.INFO)
         handler.setFormatter(
             logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -73,6 +73,8 @@ class DefaultConfig(object):
     LOG_LEVEL = "INFO"
     LOGIN_LOG_PATH = str(Path.cwd() / "logs" / "login.log")
     AUTH_LOG_PATH = str(Path.cwd() / "logs" / "auth.log")
+    AUTH_LOG_MAX_BYTES = 30 * 1024 * 1024
+    AUTH_LOG_BACKUP_COUNT = 10
     LLM_BASE_URL = None
     LLM_MODEL = ""
     LLM_MAX_CONTEXT_LENGTH = 50000

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,15 @@
+import logging
+from logging.handlers import RotatingFileHandler
+
+from gramps_webapi.app import create_app
+
+
+def test_auth_logger_uses_rotating_handler(tmp_path):
+    auth_log = tmp_path / "auth.log"
+    app = create_app({"AUTH_LOG_PATH": str(auth_log)})
+    logger = logging.getLogger("auth")
+    handler = next(
+        h for h in logger.handlers if isinstance(h, RotatingFileHandler)
+    )
+    assert handler.maxBytes == 30 * 1024 * 1024
+


### PR DESCRIPTION
## Summary
- rotate dedicated auth logger when auth.log exceeds 30MB
- document auth.log rotation behaviour
- add test verifying auth logger uses RotatingFileHandler

## Testing
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest tests/test_logging.py` *(fails: ModuleNotFoundError: No module named 'gramps')*

------
https://chatgpt.com/codex/tasks/task_e_68907a140af8832e9ec2204bef45a37e